### PR TITLE
[Latency dataset] RKNN Lite 사용

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ bash configs/iwslt14.de-en/get_preprocessed.sh
 
 ### Evolutionary Search  
 1.  Generate a latency dataset
+    * generate
     ```sh
     python latency_dataset.py --configs=configs/[task_name]/latency_dataset/[hardware_name].yml
     ```
@@ -148,6 +149,10 @@ bash configs/iwslt14.de-en/get_preprocessed.sh
     python latency_dataset.py --latnpu --configs=configs/wmt14.en-de/latency_dataset/npu.yml
     python latency_dataset.py --latnpu --configs=configs/wmt14.en-fr/latency_dataset/npu.yml
     python latency_dataset.py --latnpu --configs=configs/wmt19.en-de/latency_dataset/npu.yml
+    ```
+    * download
+    ```sh
+    gdown --folder https://drive.google.com/drive/folders/1ejT4pdvw0VM6Y0XICrnQ-iWwYaOLjxRp
     ```
 2. Train a latency predictor
     ```sh

--- a/errors/latency_dataset/latency_dataset.md
+++ b/errors/latency_dataset/latency_dataset.md
@@ -103,3 +103,27 @@ ValueError: Traceback (most recent call last):
   File "rknn/api/rknn_runtime.py", line 582, in rknn.api.rknn_runtime.RKNNRuntime.set_inputs
 Exception: Set inputs failed. error code: RKNN_ERR_PARAM_INVALID
 ```
+
+---
+## RKNN Lite
+1. iwslt
+    encoder
+    ```
+    E RKNN: [12:47:51.573] rknn_inputs_set, param input size(184) < model input size(200)
+    E Catch exception when setting inputs.
+    E Traceback (most recent call last):
+        File "/home/radxa/miniconda3/envs/rknn/lib/python3.9/site-packages/rknnlite/api/rknn_lite.py", line 209, in inference
+        self.rknn_runtime.set_inputs(inputs, data_type, data_format, inputs_pass_through=inputs_pass_through)
+        File "rknnlite/api/rknn_runtime.py", line 1164, in rknnlite.api.rknn_runtime.RKNNRuntime.set_inputs
+    Exception: Set inputs failed. error code: RKNN_ERR_PARAM_INVALID
+    ```
+    decoder
+    ```
+    E Catch exception when setting inputs.
+    E Traceback (most recent call last):
+        File "/home/radxa/miniconda3/envs/rknn/lib/python3.9/site-packages/rknnlite/api/rknn_lite.py", line 209, in inference
+        self.rknn_runtime.set_inputs(inputs, data_type, data_format, inputs_pass_through=inputs_pass_through)
+        File "rknnlite/api/rknn_runtime.py", line 1146, in rknnlite.api.rknn_runtime.RKNNRuntime.set_inputs
+    IndexError: list index out of range
+
+    ```

--- a/latency_dataset_test.py
+++ b/latency_dataset_test.py
@@ -69,8 +69,8 @@ def main(args):
             end = torch.cuda.Event(enable_timing=True)
         elif args.latnpu:
             print('Measuring model latency on NPU for dataset generation...')
-            enc = rknn_run.RKNNLite(model_name=args.rknn_model, type='enc')
-            dec = rknn_run.RKNNLite(model_name=args.rknn_model, type='dec')
+            enc = rknn_run.RKNNLite(model_name=args.data.removeprefix('data/binary/'), type='enc')
+            dec = rknn_run.RKNNLite(model_name=args.data.removeprefix('data/binary/'), type='dec')
 
         feature_info = utils.get_feature_info()
         fid.write(','.join(feature_info) + ',')

--- a/latency_dataset_test.py
+++ b/latency_dataset_test.py
@@ -69,8 +69,8 @@ def main(args):
             end = torch.cuda.Event(enable_timing=True)
         elif args.latnpu:
             print('Measuring model latency on NPU for dataset generation...')
-            enc = rknn_run.RKNNLite(model_name=args.data.removeprefix('data/binary/'), type='enc')
-            dec = rknn_run.RKNNLite(model_name=args.data.removeprefix('data/binary/'), type='dec')
+            enc = rknn_run.WrapperModelRKNNLite(model_name=args.data.removeprefix('data/binary/'), type='enc')
+            dec = rknn_run.WrapperModelRKNNLite(model_name=args.data.removeprefix('data/binary/'), type='dec')
 
         feature_info = utils.get_feature_info()
         fid.write(','.join(feature_info) + ',')

--- a/latency_dataset_test.py
+++ b/latency_dataset_test.py
@@ -173,7 +173,7 @@ def main(args):
                 incre_states = {}
                 if args.latnpu:
                     for k_regressive in range(decoder_iterations): # npu 사용 시 incremental_state 삭제
-                        model.decoder(prev_output_tokens=prev_output_tokens_test_with_beam[:, :k_regressive + 1],
+                        dec.decoder(prev_output_tokens=prev_output_tokens_test_with_beam[:, :k_regressive + 1],
                                        encoder_out=encoder_out_test_with_beam)
                 elif args.latcpu or args.latgpu:
                     for k_regressive in range(decoder_iterations):

--- a/wrapper_models/rknn_run.py
+++ b/wrapper_models/rknn_run.py
@@ -2,7 +2,7 @@ import torch
 import numpy as np
 from rknnlite.api import RKNNLite
 
-class RKNNLite:
+class WrapperModelRKNNLite:
     def __init__(self, model_name, type):
         self.type = type
         self.rknn_path = f'rknn_models/{model_name}/{model_name}_{self.type}.rknn'

--- a/wrapper_models/rknn_run.py
+++ b/wrapper_models/rknn_run.py
@@ -37,9 +37,9 @@ class WrapperModelRKNNLite:
         
     def decoder(self, prev_output_tokens, encoder_out):
         prev_output_tokens = prev_output_tokens.numpy()
-        prev_output_tokens = prev_output_tokens.reshape(1, 1, *prev_output_tokens.shape)
+        # prev_output_tokens = prev_output_tokens.reshape(1, 1, *prev_output_tokens.shape)
         encoder_out = encoder_out.numpy()
-        encoder_out = encoder_out.reshape(1, *encoder_out.shape)
+        # encoder_out = encoder_out.reshape(1, *encoder_out.shape)
         inputs = [prev_output_tokens, encoder_out] 
         return self.rknn_lite.inference(inputs=inputs)
 

--- a/wrapper_models/rknn_run.py
+++ b/wrapper_models/rknn_run.py
@@ -5,6 +5,8 @@ from rknnlite.api import RKNNLite
 class WrapperModelRKNNLite:
     def __init__(self, model_name, type):
         self.type = type
+        if model_name=='wmt16_en_de':
+            model_name = 'wmt14_en_de'
         self.rknn_path = f'rknn_models/{model_name}/{model_name}_{self.type}.rknn'
         self.rknn_lite = RKNNLite()
         print(f'| --> Load RKNN model')


### PR DESCRIPTION
# 변경 사항
## `latency_dataset_test.py` 추가
* `wrapper_models/run_rknn.py`(RKNN Lite API)를 사용하는 측정 코드 추가
* 결과: iwslt latency dataset 뽑음
* 문제: wmt 데이터셋에 대해서는 자꾸 segmentation fault 발생
---
# 앞으로 해야 할 일
정렬 기준: 금방 해결될 것 같은 순서
* 지금 만들어진 latency dataset으로 subTransformer까지 제대로 돌아가는지 확인
* wmt latency dataset 추출
* 기존 모델 CumSum부분 수정 & 수정한 모델로 변환 단계부터 다시 시작해서 산출물 뽑아내기
* 하드웨어의 channel 사이즈 고려해서 모델의 구조를 서칭하는 코드 구현