### PR TITLE
[latency_dataset] 인풋 에러 수정 및 데이터셋 추출

### DIFF
--- a/errors/latency_dataset/latency_dataset.md
+++ b/errors/latency_dataset/latency_dataset.md
@@ -212,3 +212,52 @@ Exception: Set inputs failed. error code: RKNN_ERR_PARAM_INVALID
     E RKNN: [07:47:04.114] rknn_inputs_set, param input size(184) < model input size(200)
     여기서 Segmentation fault가 난것것
     ```
+---
+
+last modified: 2025-02-10
+
+* 모든 데이터셋: 더미 인풋 사이즈를 모델의 실제 인풋 사이즈보다 1 작게(40비트 작게) 입력한 결과 segmentation fault 없이 무사히 작동
+* 특히, k_regressive를 사용하는 디코더 반복문의 경우 인덱싱에 오류가 있는 것 같아 보였음
+* 어차피 incremental_state를 사용하지 않고 + 정적 입력만 가능하기 때문에 나이브한 반복 참조문으로 변경함
+
+1. iwslt14deen
+```sh
+E RKNN: [12:04:54.561] rknn_inputs_set, param input size(960) < model input size(1000)
+E Catch exception when setting inputs.
+E Traceback (most recent call last):
+  File "/home/radxa/miniconda3/envs/rknn/lib/python3.9/site-packages/rknnlite/api/rknn_lite.py", line 209, in inference
+    self.rknn_runtime.set_inputs(inputs, data_type, data_format, inputs_pass_through=inputs_pass_through)
+  File "rknnlite/api/rknn_runtime.py", line 1164, in rknnlite.api.rknn_runtime.RKNNRuntime.set_inputs
+Exception: Set inputs failed. error code: RKNN_ERR_PARAM_INVALID
+```
+2. wmt14ende
+```sh
+E RKNN: [12:04:54.561] rknn_inputs_set, param input size(960) < model input size(1000)
+E Catch exception when setting inputs.
+E Traceback (most recent call last):
+  File "/home/radxa/miniconda3/envs/rknn/lib/python3.9/site-packages/rknnlite/api/rknn_lite.py", line 209, in inference
+    self.rknn_runtime.set_inputs(inputs, data_type, data_format, inputs_pass_through=inputs_pass_through)
+  File "rknnlite/api/rknn_runtime.py", line 1164, in rknnlite.api.rknn_runtime.RKNNRuntime.set_inputs
+Exception: Set inputs failed. error code: RKNN_ERR_PARAM_INVALID
+```
+3. wmt14enfr
+```sh
+E RKNN: [11:50:28.155] rknn_query, RKNN_QUERY_INPUT_ATTR, p_attr->index(2) >= input_num(2)!
+E Catch exception when setting inputs.
+E Traceback (most recent call last):
+  File "/home/radxa/miniconda3/envs/rknn/lib/python3.9/site-packages/rknnlite/api/rknn_lite.py", line 209, in inference
+    self.rknn_runtime.set_inputs(inputs, data_type, data_format, inputs_pass_through=inputs_pass_through)
+  File "rknnlite/api/rknn_runtime.py", line 1002, in rknnlite.api.rknn_runtime.RKNNRuntime.set_inputs
+  File "rknnlite/api/rknn_runtime.py", line 992, in rknnlite.api.rknn_runtime.RKNNRuntime.get_tensor_attr
+Exception: Query tensor attribute of input node(s) failed, error code: RKNN_ERR_PARAM_INVALID
+```
+4. wmt19ende
+```sh
+E RKNN: [12:04:54.561] rknn_inputs_set, param input size(960) < model input size(1000)
+E Catch exception when setting inputs.
+E Traceback (most recent call last):
+  File "/home/radxa/miniconda3/envs/rknn/lib/python3.9/site-packages/rknnlite/api/rknn_lite.py", line 209, in inference
+    self.rknn_runtime.set_inputs(inputs, data_type, data_format, inputs_pass_through=inputs_pass_through)
+  File "rknnlite/api/rknn_runtime.py", line 1164, in rknnlite.api.rknn_runtime.RKNNRuntime.set_inputs
+Exception: Set inputs failed. error code: RKNN_ERR_PARAM_INVALID
+```

--- a/latency_dataset_test.py
+++ b/latency_dataset_test.py
@@ -38,7 +38,7 @@ def main(args):
 
     # specify the length of the dummy input for profile
     # for iwslt, the average length is 23, for wmt, that is 30
-    dummy_sentence_length_dict = {'iwslt': 23, 'wmt': 30}
+    dummy_sentence_length_dict = {'iwslt': 25, 'wmt': 30}
     if 'iwslt' in args.arch:
         dummy_sentence_length = dummy_sentence_length_dict['iwslt']
     elif 'wmt' in args.arch:
@@ -93,6 +93,7 @@ def main(args):
                 for _ in range(5): 
                     encoder_out_test = model.encoder(src_tokens=src_tokens_test)
             if args.latnpu:
+                print("1")
                 for _ in range(5): 
                     enc.encoder(src_tokens=src_tokens_test)
 
@@ -105,6 +106,7 @@ def main(args):
                     start = time.time()
 
                 if args.latnpu:
+                    print("!! encoder")
                     enc.encoder(src_tokens=src_tokens_test)
                 elif args.latcpu or args.latgpu:
                     model.encoder(src_tokens=src_tokens_test, src_lengths=src_lengths_test)
@@ -172,8 +174,8 @@ def main(args):
 
                 incre_states = {}
                 if args.latnpu:
-                    for k_regressive in range(decoder_iterations): # npu 사용 시 incremental_state 삭제
-                        dec.decoder(prev_output_tokens=prev_output_tokens_test_with_beam[:, :k_regressive + 1],
+                    for _ in range(decoder_iterations/5): # npu 사용 시 incremental_state 삭제
+                        dec.decoder(prev_output_tokens=prev_output_tokens_test_with_beam,
                                        encoder_out=encoder_out_test_with_beam)
                 elif args.latcpu or args.latgpu:
                     for k_regressive in range(decoder_iterations):
@@ -231,3 +233,4 @@ def cli_main():
 
 if __name__ == '__main__':
     cli_main()
+

--- a/latency_dataset_test.py
+++ b/latency_dataset_test.py
@@ -46,8 +46,8 @@ def main(args):
     else:
         raise NotImplementedError
 
-    dummy_src_tokens = [2] + [7] * (dummy_sentence_length - 1)
-    dummy_prev = [7] * (dummy_sentence_length - 1) + [2]
+    dummy_src_tokens = [2] + [7] * (dummy_sentence_length - 2)
+    dummy_prev = [7] * (dummy_sentence_length - 2) + [2]
     
     # for latency predictor: latency dataset generation
     with open(args.lat_dataset_path, 'w') as fid:
@@ -93,7 +93,6 @@ def main(args):
                 for _ in range(5): 
                     encoder_out_test = model.encoder(src_tokens=src_tokens_test)
             if args.latnpu:
-                print("1")
                 for _ in range(5): 
                     enc.encoder(src_tokens=src_tokens_test)
 
@@ -106,7 +105,6 @@ def main(args):
                     start = time.time()
 
                 if args.latnpu:
-                    print("!! encoder")
                     enc.encoder(src_tokens=src_tokens_test)
                 elif args.latcpu or args.latgpu:
                     model.encoder(src_tokens=src_tokens_test, src_lengths=src_lengths_test)
@@ -138,7 +136,7 @@ def main(args):
             if args.latnpu:
                 dummy_encoder_out_length = 512
                 if dummy_sentence_length==23:
-                    dummy_sentence_length = 25
+                    dummy_sentence_length = 24
                     dummy_encoder_out_length = 640
                 encoder_out_test_with_beam = [[7] * dummy_encoder_out_length for _ in range(5)]
                 encoder_out_test_with_beam = torch.tensor([encoder_out_test_with_beam] * dummy_sentence_length, dtype=torch.long)
@@ -158,7 +156,7 @@ def main(args):
 
 
             # decoder is more complicated because we need to deal with incremental states and auto regressive things
-            decoder_iterations_dict = {'iwslt': 25, 'wmt': 30}
+            decoder_iterations_dict = {'iwslt': 24, 'wmt': 29}
             if 'iwslt' in args.arch:
                 decoder_iterations = decoder_iterations_dict['iwslt']
             elif 'wmt' in args.arch:
@@ -174,7 +172,7 @@ def main(args):
 
                 incre_states = {}
                 if args.latnpu:
-                    for _ in range(decoder_iterations/5): # npu 사용 시 incremental_state 삭제
+                    for _ in range(decoder_iterations): # npu 사용 시 incremental_state 삭제
                         dec.decoder(prev_output_tokens=prev_output_tokens_test_with_beam,
                                        encoder_out=encoder_out_test_with_beam)
                 elif args.latcpu or args.latgpu:

--- a/wrapper_models/wrapper_rknn_lite.py
+++ b/wrapper_models/wrapper_rknn_lite.py
@@ -29,8 +29,10 @@ class WrapperModelRKNNLite:
         return self.rknn_lite.inference(inputs=inputs)
     
     def encoder(self, src_tokens):
+        print(2)
         src_tokens = src_tokens.numpy()
         inputs = [src_tokens]
+        print(3)
         return self.rknn_lite.inference(inputs=inputs)
         
         

--- a/wrapper_models/wrapper_rknn_lite.py
+++ b/wrapper_models/wrapper_rknn_lite.py
@@ -4,6 +4,7 @@ from rknnlite.api import RKNNLite
 class WrapperModelRKNNLite:
     def __init__(self, model_name, type):
         self.type = type
+        self.model_name = model_name
         if model_name=='wmt16_en_de':
             model_name = 'wmt14_en_de'
         self.rknn_path = f'rknn_models/{model_name}/{model_name}_{self.type}.rknn'
@@ -35,10 +36,18 @@ class WrapperModelRKNNLite:
         
     def decoder(self, prev_output_tokens, encoder_out):
         prev_output_tokens = prev_output_tokens.numpy()
+        print(prev_output_tokens)
         encoder_out = encoder_out.numpy()
-        inputs = [prev_output_tokens, encoder_out] 
+        if 'iwslt' in self.model_name:
+            Concat_6=encoder_out.copy()
+            inputs = [prev_output_tokens, encoder_out, Concat_6]
+        elif 'wmt' in self.model_name:
+            Concat_5=encoder_out.copy()
+            Concat_6=encoder_out.copy()
+            inputs = [prev_output_tokens, encoder_out, Concat_5, Concat_6] 
         return self.rknn_lite.inference(inputs=inputs)
 
     def release(self):
         self.rknn_lite.release()
         
+

--- a/wrapper_models/wrapper_rknn_lite.py
+++ b/wrapper_models/wrapper_rknn_lite.py
@@ -29,16 +29,13 @@ class WrapperModelRKNNLite:
         return self.rknn_lite.inference(inputs=inputs)
     
     def encoder(self, src_tokens):
-        print(2)
         src_tokens = src_tokens.numpy()
         inputs = [src_tokens]
-        print(3)
-        return self.rknn_lite.inference(inputs=inputs)
+        return self.rknn_lite.inference(inputs)
         
         
     def decoder(self, prev_output_tokens, encoder_out):
         prev_output_tokens = prev_output_tokens.numpy()
-        print(prev_output_tokens)
         encoder_out = encoder_out.numpy()
         if 'iwslt' in self.model_name:
             Concat_6=encoder_out.copy()


### PR DESCRIPTION
# 변경사항
* 기존에 segmetation error 났던 부분 수정해서 wmt 데이터셋도 제대로 작동하게끔 수정
* 아직 latency dataset csv 파일 구글 드라이브에 재업로드 & train.py의 인풋 데이터 확인은 못해봄
* 모델은 CumSum 안 쓰는 버전(2025-02-09)으로 썼는데
    * 그래도 관련 에러가 발생함. 이 부분은 수현이가 다시 수정해준 버전으로 모델 변환 다시 돌린 다음에 실행해봐야 할 것 같음
---
# 앞으로 해야할 것
1. CumSum 안 쓰는 모델 변환해서 구글 드라이브에 업데이트
2. 수정한 latency_dataset_test.py로 다시 데이터셋 뽑은 뒤 
    1. 구글 드라이브에 업로드
    2. latency predictor 학습
    3. subtransformer 학습
    4. subtransformer 실행 및 테스트
3. 채널 제약조건 탐색 & 기반 서칭 구현.... 